### PR TITLE
빅픽처인터렉티브 공고 추가

### DIFF
--- a/jobs/bigpicture_interactive.json
+++ b/jobs/bigpicture_interactive.json
@@ -1,0 +1,33 @@
+{
+  "company": {
+    "name": "빅픽처인터렉티브",
+    "link": "https://lvup.gg",
+    "series_step": "B"
+  },
+  "recruits": [
+    {
+      "description": "E스포츠 플랫폼에서 백엔드 개발자를 모집합니다.",
+      "category": "BACKEND",
+      "limit_date": "2021-05-31",
+      "link": "https://www.wanted.co.kr/wd/43089",
+      "minimum_career": "ALL",
+      "minimum_qualifications": [
+        "상용서비스를 개발하였거나 운영한 경험이 있으신 분",
+        "JVM기반 생태계(Kotlin/JAVA/Spring/JPA)에 대한 이해와 엔지니어링 역량(DDD/TDD/OOP/Refactoring)을 보유하신 분",
+        "하나 이상의 프로그래밍 언어를 능숙하게 사용할 수 있으신 분",
+        "새로운 개발 환경, 언어, 기술을 익히는 것에 대한 두려움이 없으신 분",
+        "개발하는 서비스에 대한 의견을 거리낌없이 공유하시는 분",
+        "기획자, 디자이너 및 다른 엔지니어와 원활히 커뮤니케이션 할 수 있는 분"
+      ],
+      "preferred_qualifications": [
+        "게임과 e스포츠에 대한 관심이 높으신 분",
+        "Spring 프레임워크를 이용한 Web Application 개발경험이 있으신 분",
+        "Agile 개발 방법론(TDD, CI, Code Review 등)에 대한 이해도가 높은 분",
+        "객체지향 개발과 디자인패턴 사용에 익숙한 분",
+        "도메인 주도 설계를 이해하고 사용에 익숙한 분",
+        "JPA(Hibernate) 와 같은 ORM framework 사용에 익숙한 분",
+        "Microservices나 Modular Monolith 아키텍처 기반의 시스템 개발에 관심 높으신 분"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
[빅픽처인터렉티브](https://bigpi.co) 공고 추가 요청드립니다.

게임코치 아카데미를 시작으로 교육, 대회, 미디어콘텐츠, 플랫폼 사업을 진행하고 있으며, E스포츠 대회 플랫폼인 [레벨업지지](https://lvup.gg)를 함께 만들어 나갈 개발자를 모시고 있습니다.

[잡플래닛](https://www.jobplanet.co.kr/companies/347407/reviews/%EB%B9%85%ED%94%BD%EC%B2%98%EC%9D%B8%ED%84%B0%EB%A0%89%ED%8B%B0%EB%B8%8C)